### PR TITLE
end last tag with comma

### DIFF
--- a/client/src/utils/Bib.js
+++ b/client/src/utils/Bib.js
@@ -86,7 +86,7 @@ export default class Bib {
       }
     });
 
-    result += '\n}';
+    result += ',\n}';
 
     return result;
   };


### PR DESCRIPTION
Currently, the last tag of the returned bibtex is not finished by a comma. This of course satisfies the [bibtex format description](http://www.bibtex.org/Format/):  
> The last tag can be finished with a comma, although not necessarily.

However, people might like all their bibtex-entries to include the same info in the same order, say always starting with the author, followed by the title, not including the doi, …
Given a doi2bib-bibtex-entry, this is of course easiest achieved by deleting and reordering lines.

When reordering, a previously last tag that has been reordered will produce an error because of the missing comma.
Inserting this comma when reporting results fixes this.

I realize that this can and should maybe be taken care of by the person reordering their bibtex tags, but as it does not violate the bibtex format description, I think adding it doesn't hurt anyone :)