### PR TITLE
Fixes #66

### DIFF
--- a/client/src/utils/Bib.js
+++ b/client/src/utils/Bib.js
@@ -40,6 +40,9 @@ export default class Bib {
     if (this.bib.tags.pages === 'n/a-n/a') {
       delete this.bib.tags.pages;
     }
+    if (Array.isArray(this.bib.tags.pages)) {
+      this.bib.tags.pages = this.bib.tags.pages.join("");
+    }
     if (this.bib.tags.pages && this.bib.tags.pages.indexOf('--') === -1) {
       this.bib.tags.pages = this.bib.tags.pages.replace(/-/g, '--');
     }


### PR DESCRIPTION
Quick fix replaces, e.g. `this.bib.tags.pages = ['10', '436--10', '447']` with `10436--10447` by checking if `this.bib.tags.pages` is an array. See issue #66 for more.