### PR TITLE
fix(arXiv): arXiv limited support & errors

### DIFF
--- a/client/src/components/Doi2Bib.js
+++ b/client/src/components/Doi2Bib.js
@@ -80,14 +80,16 @@ class Doi2Bib extends Component {
     let idToSend = this.state.value;
     let url;
 
+    // Remove all non-ASCII chars, including non-printable, and white spaces
+    idToSend = idToSend.replace(/[^\x21-\x7E]/g, '');
+
     this.setState({
+      value: idToSend,
       bib: null,
       url: null,
       error: null,
       workInProgress: true
     });
-
-    idToSend = idToSend.replace(/[^\x21-\x7E]/g, ''); // remove all non ASCII chars, including non-printable, and white spaces
 
     if (idToSend.match(/^(doi:|(https?:\/\/)?(dx\.)?doi\.org\/)?10\..+\/.+$/i)) {
       if (idToSend.match(/^doi:/i)) {
@@ -100,8 +102,22 @@ class Doi2Bib extends Component {
     } else if (idToSend.match(/^\d+$|^PMC\d+(\.\d+)?$/)) {
       url = '/8350e5a3e24c153df2275c9f80692773/pmid2bib';
     }
-    else if (idToSend.match(/^(arxiv:)?\d+\.\d+(v(\d+))?/i)) {
-      if (idToSend.match(/^arxiv:/i)) {
+    else if (idToSend.match(/^(?:(?:https?:\/\/)?(?:www\.)?arxiv\.org\/abs\/|arxiv[:\.])?(\d+\.\d+(?:v\d+)?)/i)) {
+      /*
+        allow :
+        * https://arxiv.org/abs/XXXX.XXXXX
+        * arxiv.org/abs/XXXX.XXXXX
+        * https://doi.org/10.48550/arXiv.XXXX.XXXXX
+        * doi.org/10.48550/arXiv.XXXX.XXXXX
+        * 10.48550/arXiv.XXXX.XXXXX
+        * arXiv.XXXX.XXXXX
+        * XXXX.XXXXX
+      */
+
+      // order of condition matter
+      if (idToSend.indexOf('arxiv.org/abs/') >= 0) {
+        idToSend = idToSend.split('/').pop();
+      } else if (idToSend.match(/^arxiv\./i)) {
         idToSend = idToSend.substring(6);
       }
       url = '/8350e5a3e24c153df2275c9f80692773/arxivid2bib';

--- a/client/src/components/Doi2Bib.js
+++ b/client/src/components/Doi2Bib.js
@@ -87,7 +87,7 @@ class Doi2Bib extends Component {
       workInProgress: true
     });
 
-    idToSend = idToSend.replace(/ /g, '');
+    idToSend = idToSend.replace(/[^\x21-\x7E]/g, ''); // remove all non ASCII chars, including non-printable, and white spaces
 
     if (idToSend.match(/^(doi:|(https?:\/\/)?(dx\.)?doi\.org\/)?10\..+\/.+$/i)) {
       if (idToSend.match(/^doi:/i)) {

--- a/server/doi2bib.js
+++ b/server/doi2bib.js
@@ -66,7 +66,7 @@ function arxivid2doi(arxivid) {
       } else {
         parseString(body, function(err, result) {
           const entries = result.feed.entry;
-          if (err || !entries || !entries.length === 0) {
+          if (err || !entries?.length) {
             reject(404);
             return;
           }

--- a/server/doi2bib.js
+++ b/server/doi2bib.js
@@ -4,6 +4,8 @@ const
   request = require('request'),
   parseString = require('xml2js').parseString;
 
+const ARXIV_BASE_DOI = "10.48550";
+
 function doi2bibOptions(doi) {
   return {
     url: 'https://doi.org/' + doi,
@@ -63,12 +65,20 @@ function arxivid2doi(arxivid) {
         reject(204);
       } else {
         parseString(body, function(err, result) {
-          if (err || !result.feed.entry[0]['arxiv:doi']) {
+          const entries = result.feed.entry;
+          if (err || !entries || !entries.length === 0) {
             reject(404);
-          } else {
-            var doi = result.feed.entry[0]['arxiv:doi'][0]._;
-            resolve(doi);
+            return;
           }
+
+          const entry = entries[0];
+          var doi = null;
+          if (entry['arxiv:doi']) { // external/original DOI (if exists)
+            doi = entry['arxiv:doi'][0]._;
+          } else { // only on arvix
+            doi = `${ARXIV_BASE_DOI}/arXiv.${arxivid}`;
+          }
+          resolve(doi);
         });
       }});
     });


### PR DESCRIPTION
## arXiv limited support & errors

- Strip non-printable ASCII characters from input (fixes copy-paste issues with hidden line breaks)
- Add support for multiple arXiv URL formats (`arxiv.org/abs/`, `doi.org/10.48550/arXiv.`, bare IDs, etc.)
- Fix arXiv DOI retrieval: distinguish between external journal DOIs and arXiv-only preprints
